### PR TITLE
Add generic config mechanism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,13 @@ description = "Administrative Trussed app for SoloKeys Solo 2 security keys"
 
 [dependencies]
 apdu-dispatch = "0.1"
+cbor-smol = "0.4.0"
 ctaphid-dispatch = "0.1"
 delog = "0.1"
 iso7816 = "0.1"
+littlefs2 = "0.4"
+serde = { version = "1.0.180", default-features = false }
+strum_macros = "0.25.2"
 trussed = "0.1"
 
 se05x = { version = "0.0.1", optional = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,134 @@
+use core::{
+    fmt::{self, Display, Formatter, Write as _},
+    str::FromStr,
+};
+
+use cbor_smol::{cbor_deserialize, cbor_serialize_bytes};
+use littlefs2::{path, path::Path};
+use serde::{de::DeserializeOwned, Serialize};
+use strum_macros::FromRepr;
+use trussed::{
+    store::filestore::Filestore,
+    try_syscall,
+    types::{Location, Message, Vec},
+    Client,
+};
+
+const LOCATION: Location = Location::Internal;
+const FILENAME: &Path = path!("config");
+
+pub trait Config: Default + PartialEq + DeserializeOwned + Serialize {
+    fn field(&mut self, key: &str) -> Option<ConfigValueMut<'_>>;
+}
+
+impl Config for () {
+    fn field(&mut self, _key: &str) -> Option<ConfigValueMut<'_>> {
+        None
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub enum ConfigValueMut<'a> {
+    Bool(&'a mut bool),
+    U8(&'a mut u8),
+}
+
+impl<'a> ConfigValueMut<'a> {
+    fn set(&mut self, value: &str) -> Result<(), ConfigError> {
+        fn set_value<T: FromStr>(target: &mut T, s: &str) -> Result<(), ConfigError> {
+            *target = s.parse().map_err(|_| ConfigError::InvalidValue)?;
+            Ok(())
+        }
+
+        match self {
+            Self::Bool(r) => set_value(*r, value),
+            Self::U8(r) => set_value(*r, value),
+        }
+    }
+}
+
+impl<'a> Display for ConfigValueMut<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Bool(value) => write!(f, "{}", value),
+            Self::U8(value) => write!(f, "{}", value),
+        }
+    }
+}
+
+#[derive(Debug, FromRepr)]
+#[repr(u8)]
+pub enum ConfigError {
+    ReadFailed = 1,
+    WriteFailed = 2,
+    DeserializationFailed = 3,
+    SerializationFailed = 4,
+    InvalidKey = 5,
+    InvalidValue = 6,
+    DataTooLong = 7,
+}
+
+const _: () = assert!(
+    ConfigError::from_repr(0).is_none(),
+    "ConfigError may not have a variant with discriminant zero as zero indicates success.",
+);
+
+impl From<ConfigError> for u8 {
+    fn from(error: ConfigError) -> u8 {
+        error as _
+    }
+}
+
+pub fn get<C: Config, const N: usize>(
+    config: &mut C,
+    key: &str,
+    response: &mut Vec<u8, N>,
+) -> Result<(), ConfigError> {
+    let field = config.field(key).ok_or(ConfigError::InvalidKey)?;
+    write!(response, "{}", field).map_err(|_| ConfigError::DataTooLong)
+}
+
+pub fn set<C: Config>(config: &mut C, key: &str, value: &str) -> Result<(), ConfigError> {
+    config.field(key).ok_or(ConfigError::InvalidKey)?.set(value)
+}
+
+pub fn load<F: Filestore, C: Config>(store: &mut F) -> Result<C, ConfigError> {
+    let Some(data) = load_if_exists(store, LOCATION, FILENAME)? else {
+        return Ok(Default::default());
+    };
+    cbor_deserialize(&data).map_err(|_| ConfigError::DeserializationFailed)
+}
+
+pub fn save<T: Client, C: Config>(client: &mut T, config: &C) -> Result<(), ConfigError> {
+    if config == &Default::default() {
+        if exists(client, LOCATION, FILENAME)? {
+            try_syscall!(client.remove_file(LOCATION, FILENAME.into()))
+                .map_err(|_| ConfigError::WriteFailed)?;
+        }
+    } else {
+        let data = cbor_serialize_bytes(config).map_err(|_| ConfigError::SerializationFailed)?;
+        try_syscall!(client.write_file(LOCATION, FILENAME.into(), data, None))
+            .map_err(|_| ConfigError::WriteFailed)?;
+    }
+    Ok(())
+}
+
+fn exists<T: Client>(client: &mut T, location: Location, path: &Path) -> Result<bool, ConfigError> {
+    try_syscall!(client.entry_metadata(location, path.into()))
+        .map(|r| r.metadata.is_some())
+        .map_err(|_| ConfigError::ReadFailed)
+}
+
+fn load_if_exists<F: Filestore>(
+    store: &mut F,
+    location: Location,
+    path: &Path,
+) -> Result<Option<Message>, ConfigError> {
+    store.read(path, location).map(Some).or_else(|_| {
+        if store.exists(path, location) {
+            Err(ConfigError::ReadFailed)
+        } else {
+            Ok(None)
+        }
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,10 @@ extern crate delog;
 generate_macros!();
 
 mod admin;
+mod config;
+
 pub use admin::{App, Reboot};
+pub use config::{Config, ConfigError, ConfigValueMut};
 
 #[cfg(not(feature = "se050"))]
 pub trait Client: trussed::Client {}


### PR DESCRIPTION
This patch adds a generic configuration mechanism to the admin app. There are two new commands, GET_CONFIG and SET_CONFIG, that can be used to query and change configuration values by key.  The runner is responsible for providing the configuration struct and a mapping from key to field.

Points to discuss:
1. This implementation stores a format version in the config file.  We could drop that and just change the file name if we change format.
2. The config is loaded when the app is created and kept in memory during the app’s lifetime.  We could also just load it on demand.
3. Currently, we just panic on load failure.  It could be better to just the default settings and signal an error.
4. Do we need touch confirmation for the get/set operations?  