### PR TITLE
se050 test: Return UnsuportedCommand (INVALID_COMMAND) instead of NotAvailable (INVALID_LENGTH)

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -276,7 +276,7 @@ where
                 }
                 #[cfg(not(feature = "se050"))]
                 {
-                    return Err(Error::NotAvailable);
+                    return Err(Error::UnsupportedCommand);
                 }
             }
             Command::GetConfig => {


### PR DESCRIPTION
This allows nitropy to easily skip the test if the command is not supported