### PR TITLE
Implement factory reset functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ embedded-hal = { version = "0.2.7", optional = true }
 hex-literal = "0.4.1"
 rand_chacha = { version = "0.3.1", optional = true, default-features = false }
 trussed-se050-backend = { version = "0.1.0", optional = true }
+trussed-staging = { version = "0.1.0", features = ["manage"] }
 
 [features]
 default = []
@@ -44,3 +45,4 @@ apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev 
 trussed-se050-backend = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", rev = "3395a5b73241a0a9f14a0715952be6fe7f1e56b0" }
 iso7816 = { git = "https://github.com/sosthene-nitrokey/iso7816.git", rev = "160ca3bbd8e21ec4e4ee1e0748e1eaa53a45c97f"}
 se05x = { git = "https://github.com/Nitrokey/se05x.git", rev = "0b77eb6b152d214897696aadf87767fd84ffcb0e"} 
+trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "10baac2608e98e25ea77ade974a4e26f778d6c8e" }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -302,6 +302,7 @@ where
             Command::FactoryReset => {
                 debug_now!("Factory resetting the device");
                 syscall!(self.trussed.factory_reset_device());
+                R::reboot();
             }
         }
         Ok(())

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -334,7 +334,7 @@ where
                 }
                 let path = PathBuf::from(client);
 
-                // No need to factory reset is already factory reset
+                // No need to factory reset if already factory reset
                 if flag.set_factory_reset() {
                     syscall!(self.trussed.factory_reset_client(&path));
                 }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -19,6 +19,7 @@ const STATUS: u8 = 0x80;
 const TEST_SE050: u8 = 0x81;
 const GET_CONFIG: u8 = 0x82;
 const SET_CONFIG: u8 = 0x83;
+const FACTORY_RESET: u8 = 0x84;
 
 // For compatibility, old commands are also available directly as separate vendor commands.
 const UPDATE: VendorCommand = VendorCommand::H51;
@@ -48,6 +49,7 @@ enum Command {
     TestSe05X,
     GetConfig,
     SetConfig,
+    FactoryReset,
 }
 
 impl TryFrom<u8> for Command {
@@ -67,6 +69,7 @@ impl TryFrom<u8> for Command {
             TEST_SE050 => Ok(Command::TestSe05X),
             GET_CONFIG => Ok(Command::GetConfig),
             SET_CONFIG => Ok(Command::SetConfig),
+            FACTORY_RESET => Ok(Command::FactoryReset),
             _ => Err(Error::UnsupportedCommand),
         }
     }
@@ -294,6 +297,10 @@ where
                     Err(error) => error.into(),
                 };
                 response.push(status).ok();
+            }
+            Command::FactoryReset => {
+                debug_now!("Factory resetting the device");
+                syscall!(self.trussed.factory_reset_device());
             }
         }
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,8 +48,15 @@ impl ResetSignalAllocation {
     /// Factory reset can be acknowledged so that the application can restart working
     ///
     /// A configuration change cannot be acknowledged as it requires a power cycle to be taken into account.
-    pub fn ack_factory_reset(&self) {
-        self.0.store(ResetSignal::None as u8, Ordering::Relaxed)
+    pub fn ack_factory_reset(&self) -> bool {
+        self.0
+            .compare_exchange(
+                ResetSignal::FactoryReset as u8,
+                ResetSignal::None as u8,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            )
+            .is_ok()
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,10 @@ use trussed::{
 pub struct ResetSignalAllocation(AtomicU8);
 
 impl ResetSignalAllocation {
+    pub const fn new() -> Self {
+        Self(AtomicU8::new(ResetSignal::None as u8))
+    }
+
     pub fn load(&self) -> ResetSignal {
         let v = self.0.load(Ordering::Relaxed);
         ResetSignal::from_repr(v).expect("A reset signal value")

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,8 +45,7 @@ impl ResetSignalAllocation {
     ///
     /// A configuration change cannot be acknowledged as it requires a power cycle to be taken into account.
     pub fn ack_factory_reset(&self) {
-        self.0
-            .store(ResetSignal::ConfigChanged as u8, Ordering::Relaxed)
+        self.0.store(ResetSignal::None as u8, Ordering::Relaxed)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,6 +87,7 @@ pub enum ConfigError {
     InvalidKey = 5,
     InvalidValue = 6,
     DataTooLong = 7,
+    NotConfirmed = 8,
 }
 
 const _: () = assert!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod admin;
 mod config;
 
 pub use admin::{App, Reboot};
-pub use config::{Config, ConfigError, ConfigValueMut};
+pub use config::{Config, ConfigError, ConfigValueMut, ResetSignal, ResetSignalAllocation};
 use trussed_staging::manage::ManageClient;
 
 #[cfg(not(feature = "se050"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ pub trait Client: trussed::Client + ManageClient {}
 impl<C: trussed::Client + ManageClient> Client for C {}
 
 #[cfg(feature = "se050")]
-pub trait Client: trussed::Client + trussed_se050_backend::manage::ManageClient {}
+pub trait Client:
+    trussed::Client + trussed_se050_backend::manage::ManageClient + ManageClient
+{
+}
 #[cfg(feature = "se050")]
-impl<C: trussed::Client + trussed_se050_backend::manage::ManageClient> Client for C {}
+impl<C: trussed::Client + trussed_se050_backend::manage::ManageClient + ManageClient> Client for C {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,12 @@ mod config;
 
 pub use admin::{App, Reboot};
 pub use config::{Config, ConfigError, ConfigValueMut};
+use trussed_staging::manage::ManageClient;
 
 #[cfg(not(feature = "se050"))]
-pub trait Client: trussed::Client {}
+pub trait Client: trussed::Client + ManageClient {}
 #[cfg(not(feature = "se050"))]
-impl<C: trussed::Client> Client for C {}
+impl<C: trussed::Client + ManageClient> Client for C {}
 
 #[cfg(feature = "se050")]
 pub trait Client: trussed::Client + trussed_se050_backend::manage::ManageClient {}


### PR DESCRIPTION
This patch implements factory reset leveraging the [management extension](https://github.com/trussed-dev/trussed-staging/pull/11).

It adds 2 features:

- A command to factory reset the entire device
- Factory resetting a given client after changing a configuration value. This factory resetting is contlrolled by the `Config` `impl`.