### PR TITLE
Add App::without_config constructor

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -178,7 +178,7 @@ pub trait Reboot {
     fn locked() -> bool;
 }
 
-pub struct App<T, R, S, C> {
+pub struct App<T, R, S, C = ()> {
     trussed: T,
     uuid: [u8; 16],
     version: u32,
@@ -188,6 +188,27 @@ pub struct App<T, R, S, C> {
     config: C,
 }
 
+impl<T, R, S> App<T, R, S, ()>
+where
+    T: TrussedClient,
+    R: Reboot,
+    S: AsRef<[u8]>,
+{
+    /// Create an admin app instance without the configuration mechanism.
+    ///
+    /// This is only intended for testing and example code.  Firmware runners should use
+    /// [`App::load`][].
+    pub fn without_config(
+        client: T,
+        uuid: [u8; 16],
+        version: u32,
+        full_version: &'static str,
+        status: S,
+    ) -> Self {
+        Self::new(client, uuid, version, full_version, status, ())
+    }
+}
+
 impl<T, R, S, C> App<T, R, S, C>
 where
     T: TrussedClient,
@@ -195,6 +216,7 @@ where
     S: AsRef<[u8]>,
     C: Config,
 {
+    /// Create an admin app instance, loading the configuration from the filesystem.
     pub fn load<F: Filestore>(
         client: T,
         filestore: &mut F,


### PR DESCRIPTION
For testing, e. g. in websmartcard, the config feature is not necessary. This patch adds a without_config constructor to the App to make it easier to setup the app in such cases.