### PR TITLE
Refactor App constructors

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -224,10 +224,13 @@ where
         version: u32,
         full_version: &'static str,
         status: S,
-    ) -> Self {
+    ) -> Result<Self, ConfigError> {
         config::load(filestore)
             .map(|config| Self::new(client, uuid, version, full_version, status, config))
-            .unwrap()
+            .map_err(|err| {
+                error!("failed to load configuration: {:?}", err);
+                err
+            })
     }
 
     fn new(

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -203,13 +203,21 @@ where
         version: u32,
         full_version: &'static str,
         status: S,
-    ) -> Result<Self, ConfigError> {
-        config::load(filestore)
-            .map(|config| Self::new(client, uuid, version, full_version, status, config))
-            .map_err(|err| {
+    ) -> Result<Self, (T, ConfigError)> {
+        match config::load(filestore) {
+            Ok(config) => Ok(Self::new(
+                client,
+                uuid,
+                version,
+                full_version,
+                status,
+                config,
+            )),
+            Err(err) => {
                 error!("failed to load configuration: {:?}", err);
-                err
-            })
+                Err((client, err))
+            }
+        }
     }
 
     /// Create an admin app instance without the configuration mechanism, using the default config

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -188,27 +188,6 @@ pub struct App<T, R, S, C = ()> {
     config: C,
 }
 
-impl<T, R, S> App<T, R, S, ()>
-where
-    T: TrussedClient,
-    R: Reboot,
-    S: AsRef<[u8]>,
-{
-    /// Create an admin app instance without the configuration mechanism.
-    ///
-    /// This is only intended for testing and example code.  Firmware runners should use
-    /// [`App::load`][].
-    pub fn without_config(
-        client: T,
-        uuid: [u8; 16],
-        version: u32,
-        full_version: &'static str,
-        status: S,
-    ) -> Self {
-        Self::new(client, uuid, version, full_version, status, ())
-    }
-}
-
 impl<T, R, S, C> App<T, R, S, C>
 where
     T: TrussedClient,
@@ -217,7 +196,7 @@ where
     C: Config,
 {
     /// Create an admin app instance, loading the configuration from the filesystem.
-    pub fn load<F: Filestore>(
+    pub fn load_config<F: Filestore>(
         client: T,
         filestore: &mut F,
         uuid: [u8; 16],
@@ -231,6 +210,28 @@ where
                 error!("failed to load configuration: {:?}", err);
                 err
             })
+    }
+
+    /// Create an admin app instance without the configuration mechanism, using the default config
+    /// values.
+    ///
+    /// This is only intended for debugging, testing and example code.  In production,
+    /// [`App::load_config`][] should be used.
+    pub fn with_default_config(
+        client: T,
+        uuid: [u8; 16],
+        version: u32,
+        full_version: &'static str,
+        status: S,
+    ) -> Self {
+        Self::new(
+            client,
+            uuid,
+            version,
+            full_version,
+            status,
+            Default::default(),
+        )
     }
 
     fn new(


### PR DESCRIPTION
Previously, we assumed that we can always read from the IFS and panicked if that failed.  This PR changes `App::load` to return an error instead and renames it to `App::load_config`.  The runner can then decide whether it panics, skips the admin app or uses the default config (`App::with_default_config`, renamed from `App::without_config` and extended to work with any `Config` implementation).