### PR TITLE
Increase timeout for reboot to bootloader

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -15,7 +15,7 @@ use trussed::{interrupt::InterruptFlag, store::filestore::Filestore, syscall, ty
 use crate::config::{self, Config, ConfigError};
 use crate::migrations::Migrator;
 
-pub const USER_PRESENCE_TIMEOUT_SECS: u32 = 15;
+pub const USER_PRESENCE_TIMEOUT_SECS: u32 = 30;
 
 // New commands are only available over this vendor command (acting as a namespace for this
 // application).  The actual application command is stored in the first byte of the packet data.


### PR DESCRIPTION
Previously, we had a timeout of 15 seconds for the user presence check when rebooting to bootloader.  This can be too short in some situations, see for example https://github.com/Nitrokey/nitrokey-3-firmware/issues/519.

This patch increases the timeout to 30 seconds.