### PR TITLE
Revert "Increase timeout for reboot to bootloader"

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -15,7 +15,7 @@ use trussed::{interrupt::InterruptFlag, store::filestore::Filestore, syscall, ty
 use crate::config::{self, Config, ConfigError};
 use crate::migrations::Migrator;
 
-pub const USER_PRESENCE_TIMEOUT_SECS: u32 = 30;
+pub const USER_PRESENCE_TIMEOUT_SECS: u32 = 15;
 
 // New commands are only available over this vendor command (acting as a namespace for this
 // application).  The actual application command is stored in the first byte of the packet data.


### PR DESCRIPTION
This reverts commit 37d543725752d427988273ddbf27723945067414.

I misunderstood the requirement described in https://github.com/Nitrokey/nitrokey-3-firmware/issues/519, so this change was unnecessary.

See also: https://github.com/Nitrokey/admin-app/pull/27