### PR TITLE
Update trussed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ delog = "0.1"
 heapless = "0.7"
 heapless-bytes = "0.3"
 iso7816 = "0.1"
-littlefs2 = { version = "0.5", optional = true }
+littlefs2 = { version = "0.6", optional = true }
 littlefs2-core = { version = "0.1", features = ["heapless-bytes03"] }
 serde = { version = "1.0.180", default-features = false }
 strum_macros = "0.25.2"
@@ -46,4 +46,4 @@ log-error = []
 migration-tests = ["dep:littlefs2"]
 
 [patch.crates-io]
-trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "6bba8fde36d05c0227769eb63345744e87d84b2b" }
+trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "5003249c3187dca841f83551ba625921611a5ace" }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -263,7 +263,7 @@ where
 
         for migration in self.migrations {
             if migration.version > current_version && migration.version <= to_version {
-                (migration.migrate)(&**internal, &**external).map_err(|_err| {
+                (migration.migrate)(internal, external).map_err(|_err| {
                     error_now!("Migration failed: {_err:?}");
                     ConfigError::WriteFailed
                 })?;

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -82,19 +82,17 @@ pub mod test_utils {
     }
 
     ram_storage!(
-        name=NoBackendStorage,
-        backend=RamDirect,
-        trait=littlefs2::driver::Storage,
-        erase_value=0xff,
-        read_size=16,
-        write_size=16,
-        cache_size_ty=littlefs2::consts::U512,
-        block_size=512,
-        block_count=128,
-        lookahead_size_ty=littlefs2::consts::U8,
-        filename_max_plus_one_ty=littlefs2::consts::U256,
-        path_max_plus_one_ty=littlefs2::consts::U256,
-        result=Result,
+        name = NoBackendStorage,
+        backend = RamDirect,
+        erase_value = 0xff,
+        read_size = 16,
+        write_size = 16,
+        cache_size_ty = littlefs2::consts::U512,
+        block_size = 512,
+        block_count = 128,
+        lookahead_size_ty = littlefs2::consts::U8,
+        filename_max_plus_one_ty = littlefs2::consts::U256,
+        path_max_plus_one_ty = littlefs2::consts::U256,
     );
 
     pub fn test_migration_one(


### PR DESCRIPTION
The simplified Store trait no longer uses the Fs indirection so we can simplify the code calling the migration functions.

This patch also updates littlefs2 to avoid duplicate dependencies.